### PR TITLE
Implement support for Post field of "full_picture"

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/Post.java
+++ b/facebook4j-core/src/main/java/facebook4j/Post.java
@@ -31,6 +31,7 @@ public interface Post extends FacebookResponse {
     String getMessage();
     List<Tag> getMessageTags();
     URL getPicture();
+    URL getFullPicture();
     URL getLink();
     String getName();
     String getCaption();

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/PostJSONImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/PostJSONImpl.java
@@ -58,6 +58,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
     private String message;
     private List<Tag> messageTags;
     private URL picture;
+    private URL fullPicture;
     private URL link;
     private String name;
     private String caption;
@@ -143,6 +144,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
                 messageTags = Collections.emptyList();
             }
             picture = getURL("picture", json);
+            fullPicture = getURL("full_picture", json);
             link = getURL("link", json);
             name = getRawString("name", json);
             caption = getRawString("caption", json);
@@ -266,7 +268,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
             throw new FacebookException(jsone.getMessage(), jsone);
         }
     }
-    
+
     public String getId() {
         return id;
     }
@@ -289,6 +291,10 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
 
     public URL getPicture() {
         return picture;
+    }
+
+    public URL getFullPicture() {
+      return fullPicture;
     }
 
     public URL getLink() {
@@ -455,6 +461,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
                 ", message='" + message + '\'' +
                 ", messageTags=" + messageTags +
                 ", picture=" + picture +
+                ", fullPicture=" + fullPicture +
                 ", link=" + link +
                 ", name='" + name + '\'' +
                 ", caption='" + caption + '\'' +
@@ -485,7 +492,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
 
     private class PropertyJSONImpl implements Post.Property, java.io.Serializable {
         private static final long serialVersionUID = -2917519371927503549L;
-        
+
         private final String name;
         private final String text;
         private final String href;
@@ -518,7 +525,7 @@ final class PostJSONImpl extends FacebookResponseImpl implements Post, java.io.S
 
     private class ActionJSONImpl implements Post.Action, java.io.Serializable {
         private static final long serialVersionUID = 2407371708630166786L;
-        
+
         private final String name;
         private final String link;
 

--- a/facebook4j-core/src/test/java/facebook4j/PageMethodsTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/PageMethodsTest.java
@@ -722,6 +722,7 @@ public class PageMethodsTest {
             assertThat(post.getLink().toString(), is("http://www.runningtowardshome.com/2013/06/grand-canyon-r2r2r.html"));
             assertThat(post.getName(), is("Running Towards Home | ©: My Quest to Run the Grand Canyon R2R2R"));
             assertThat(post.getPicture().toString(), is("https://fbexternal-a.akamaihd.net/safe_image.php?d=AQCk6K-KS0vS1qlM&w=154&h=154&url=http%3A%2F%2F3.bp.blogspot.com%2F-rbFFZFuvNiQ%2FUX33eAIvYjI%2FAAAAAAAAN2g%2FmJUZSlj7B1M%2Fs240%2FBeforeAfter2.png"));
+            assertThat(post.getFullPicture().toString(), is("https://fbcdn-sphotos-f-a.akamaihd.net/hphotos-ak-frc1/q75/s480x480/1001458_203494769804107_274974554_full_picture.jpg"));
             assertThat(tagged4.getMessage(), is("I've gotten the bug. My new addition to my bucket list? Run the Grand Canyon Rim to Rim to Rim. This needs to happen. 2014 anyone?"));
             assertThat(tagged4.getMessageTags().size(), is(1));
             assertThat(tagged4.getMessageTags().get("64").length, is(1));

--- a/facebook4j-core/src/test/java/facebook4j/PostMethodsTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/PostMethodsTest.java
@@ -61,6 +61,7 @@ public class PostMethodsTest extends MockFacebookTestBase {
             assertThat(actual1.getId(), is("1234567890123456_500000000000001"));
             assertThat(actual1.getMessage(), is("Sunrise"));
             assertThat(actual1.getPicture().toString(), is("https://fbcdn-photos-a-a.akamaihd.net/hphotos-ak-prn2/1098080_570000000000001_1269337662_s.jpg"));
+            assertThat(actual1.getFullPicture().toString(), is("https://fbcdn-photos-a-a.akamaihd.net/hphotos-ak-prn2/1098080_570000000000001_1269337662_full_picture.jpg"));
             assertThat(actual1.getStatusType(), is("mobile_status_update"));
             assertThat(actual1.getLikes().getCount(), is(13));
             assertThat(actual1.getLikes().get(0).getId(), is("100000000000011"));
@@ -145,6 +146,7 @@ public class PostMethodsTest extends MockFacebookTestBase {
             assertThat(actual1.getId(), is("1234567890123456_500000000000001"));
             assertThat(actual1.getMessage(), is("Sunrise"));
             assertThat(actual1.getPicture().toString(), is("https://fbcdn-photos-a-a.akamaihd.net/hphotos-ak-prn2/1098080_570000000000001_1269337662_s.jpg"));
+            assertThat(actual1.getFullPicture().toString(), is("https://fbcdn-photos-a-a.akamaihd.net/hphotos-ak-prn2/1098080_570000000000001_1269337662_full_picture.jpg"));
             assertThat(actual1.getStatusType(), is("mobile_status_update"));
             assertThat(actual1.getLikes().getCount(), is(13));
             assertThat(actual1.getLikes().get(0).getId(), is("100000000000011"));
@@ -226,6 +228,7 @@ public class PostMethodsTest extends MockFacebookTestBase {
             assertThat(actual1.getId(), is("100000000000001_410000000000001"));
             assertThat(actual1.getMessage(), is("Ebi"));
             assertThat(actual1.getPicture().toString(), is("https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-frc3/1185014_410000000000002_1666290908_s.jpg"));
+            assertThat(actual1.getFullPicture().toString(), is("https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-frc3/1185014_410000000000002_1666290908_full_picture.jpg"));
             assertThat(actual1.getStatusType(), is("added_photos"));
             assertThat(actual1.getLikes().getCount(), is(1));
             assertThat(actual1.getLikes().get(0).getId(), is("100000300000000"));
@@ -555,6 +558,7 @@ public class PostMethodsTest extends MockFacebookTestBase {
             assertThat(actual.getUpdatedTime(), is(iso8601DateOf("2013-08-18T12:03:22+0000")));
             assertThat(actual.getId(), is("19292868552_10150189643478553"));
             assertThat(actual.getPicture().toString(), is("https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F"));
+            assertThat(actual.getFullPicture().toString(), is("https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F&full_picture"));
             assertThat(actual.getStatusType(), is("app_created_story"));
             assertThat(actual.getDescription(), is("\nWe continue to make Platform more secure for users. Earlier this year, we introduced the ability for users to browse Facebook over HTTPS. As a result, we provided \u201cSecure Canvas URL\u201d and \u201cSecure Tab URL\u201d fields in the Developer App for developers to serve their apps through an H"));
             assertThat(actual.getLikes().getCount(), is(8064));

--- a/facebook4j-core/src/test/resources/mock_json/page/tagged.json
+++ b/facebook4j-core/src/test/resources/mock_json/page/tagged.json
@@ -20,6 +20,7 @@
                 "id": "100004307554645",
                 "name": "Mein Herr Schmidt"
             },
+            "full_picture": "https://fbcdn-sphotos-f-a.akamaihd.net/hphotos-ak-frc1/q75/s480x480/1001458_203494769804107_274974554_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_203494769804107",
             "likes": {
@@ -62,6 +63,7 @@
                 "id": "100004307554645",
                 "name": "Mein Herr Schmidt"
             },
+            "full_picture": "https://fbcdn-sphotos-d-a.akamaihd.net/hphotos-ak-prn2/q77/s480x480/6583_203494533137464_688033670_full_contact.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_203494533137464",
             "link": "http://www.facebook.com/photo.php?fbid=203494533137464&set=o.65341080064&type=1",
@@ -124,6 +126,7 @@
                 "id": "1558890061",
                 "name": "Joshua Snow Hansén"
             },
+            "full_picture": "https://fbcdn-sphotos-f-a.akamaihd.net/hphotos-ak-frc1/q75/s480x480/1001458_203494769804107_274974554_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yD/r/aS8ecmYRys0.gif",
             "id": "65341080064_10152888395585065",
             "link": "http://www.runningtowardshome.com/2013/06/grand-canyon-r2r2r.html",
@@ -218,6 +221,7 @@
                 "id": "617215601621897",
                 "name": "Ceylon's Pride"
             },
+            "full_picture": "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/373029_617215601621897_2089487462_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yD/r/aS8ecmYRys0.gif",
             "id": "65341080064_619796861363771",
             "link": "http://www.facebook.com/CeylonsPride",
@@ -281,6 +285,7 @@
                 "id": "691374400",
                 "name": "John DeLanghe"
             },
+            "full_picture": "https://fbexternal-a.akamaihd.net/safe_image.php?d=AQDEyOas7zVTfgSY&w=130&h=130&url=http%3A%2F%2Fi1.ytimg.com%2Fvi%2F8P-VE8K1O6U%2Fmaxresdefault.jpg%3Ffeature%3Dog&full_picture",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yj/r/v2OnaTyTQZE.gif",
             "id": "65341080064_10151515892704401",
             "link": "https://www.youtube.com/watch?v=8P-VE8K1O6U",
@@ -317,6 +322,7 @@
                 "id": "100001970769475",
                 "name": "Anke van Griensven"
             },
+            "full_picture": "https://fbcdn-sphotos-h-a.akamaihd.net/hphotos-ak-prn1/q77/s480x480/941954_470311716377850_472162414_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_470311716377850",
             "link": "http://www.facebook.com/photo.php?fbid=470311716377850&set=o.65341080064&type=1",
@@ -351,6 +357,7 @@
                 "id": "100000007358858",
                 "name": "Valerie Mcgonigal"
             },
+            "full_picture": "https://fbcdn-sphotos-h-a.akamaihd.net/hphotos-ak-prn2/q77/s480x480/970544_610835625593344_977199069_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_610835625593344",
             "link": "http://www.facebook.com/photo.php?fbid=610835625593344&set=o.65341080064&type=1",
@@ -385,6 +392,7 @@
                 "id": "100000007358858",
                 "name": "Valerie Mcgonigal"
             },
+            "full_picture": "https://fbcdn-sphotos-a-a.akamaihd.net/hphotos-ak-prn1/q75/s480x480/942387_610835078926732_1487148788_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_610835078926732",
             "likes": {
@@ -576,6 +584,7 @@
                 "id": "100000117177620",
                 "name": "Terri Hadley-kirk"
             },
+            "full_picture": "https://fbexternal-a.akamaihd.net/safe_image.php?d=AQAgVFmHEXFYNWsr&w=154&h=154&url=http%3A%2F%2Fcdn2.hubspot.net%2Fhub%2F53%2Ffile-30745478-png%2FFB-for-Business_full_picture.png",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yD/r/aS8ecmYRys0.gif",
             "id": "65341080064_10152796970635065",
             "link": "http://offers.hubspot.com/facebook-for-business-facebook?source=hspd-facebook-ad-facebook-for-business-ebook-20130501",
@@ -787,6 +796,7 @@
                 "id": "135393633232510",
                 "name": "California Grocers Association"
             },
+            "full_picture": "https://fbcdn-photos-e-a.akamaihd.net/hphotos-ak-ash3/45285_10151605252482848_734868386_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yD/r/aS8ecmYRys0.gif",
             "id": "65341080064_10152737768860065",
             "link": "http://www.facebook.com/photo.php?fbid=10151605252482848&set=a.96664542847.108567.69494492847&type=1",
@@ -875,6 +885,7 @@
                 "id": "1562498444",
                 "name": "Bob Murray"
             },
+            "full_picture": "https://fbcdn-sphotos-f-a.akamaihd.net/hphotos-ak-ash3/s480x480/17188_4756436479821_1457946461_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "65341080064_4756436479821",
             "likes": {

--- a/facebook4j-core/src/test/resources/mock_json/post/feed.json
+++ b/facebook4j-core/src/test/resources/mock_json/post/feed.json
@@ -21,6 +21,7 @@
                 "id": "1234567890123456",
                 "name": "My Name"
             },
+            "full_picture": "https://fbcdn-photos-a-a.akamaihd.net/hphotos-ak-prn2/1098080_570000000000001_1269337662_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yx/r/zzzzzzzz.gif",
             "id": "1234567890123456_500000000000001",
             "likes": {
@@ -81,6 +82,7 @@
                 "id": "1234567890123456",
                 "name": "My Name"
             },
+            "full_picture": "https://fbcdn-photos-h-a.akamaihd.net/hphotos-ak-ash4/1001576_570000000000002_1789951243_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yx/r/yyyyyyyy.gif",
             "id": "1234567890123456_500000000000001",
             "likes": {
@@ -221,6 +223,7 @@
                 "id": "1234567890123456",
                 "name": "My Name"
             },
+            "full_picture": "https://fbexternal-a.akamaihd.net/safe_image.php?d=AQDM5pinjG0DWVBV&w=50&h=50&url=http%3A%2F%2Fwww.harumi-triton.jp%2Fcommon%2Fimages%2Fh1_img_001.gif&crop&fallback=hub_place&prefix=q%full_image",
             "icon": "https://www.facebook.com/images/icons/place.png",
             "id": "1234567890123456_500000000000004",
             "likes": {
@@ -292,6 +295,7 @@
                 "id": "1234567890123456",
                 "name": "My Name"
             },
+            "full_picture": "https://fbcdn-photos-b-a.akamaihd.net/hphotos-ak-ash3/644169_573207722741517_740837405_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/StEh3RhPvjk.gif",
             "id": "1234567890123456_500000000000005",
             "link": "https://www.facebook.com/photo.php?fbid=573207722741517&set=a.573203529408603.1073741827.1234567890123456&type=1&relevant_count=1",
@@ -353,6 +357,7 @@
                 "id": "100000000000008",
                 "name": "Tag Name1"
             },
+            "full_picture": "https://fbcdn-profile-a.akamaihd.net/static-ak/rsrc.php/v2/y5/r/wwwwwwwwww_full_picture.jpg",
             "icon": "https://www.facebook.com/images/icons/place.png",
             "id": "1234567890123456_500000000000006",
             "likes": {

--- a/facebook4j-core/src/test/resources/mock_json/post/home.json
+++ b/facebook4j-core/src/test/resources/mock_json/post/home.json
@@ -21,6 +21,7 @@
                 "id": "100000000000001",
                 "name": "Friend Name1"
             },
+            "full_picture": "https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-frc3/1185014_410000000000002_1666290908_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yx/r/zzzz1.gif",
             "id": "100000000000001_410000000000001",
             "likes": {
@@ -78,6 +79,7 @@
                 "id": "100000000000002",
                 "name": "Friend Name2"
             },
+            "full_picture": "https://fbcdn-photos-h-a.akamaihd.net/hphotos-ak-prn2/fafafafafaafdfa_full_picture.jpg",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yx/r/zzzz2.gif",
             "id": "100000000000002_410000000000003",
             "likes": {
@@ -127,6 +129,7 @@
                 "id": "100000000000003",
                 "name": "bird"
             },
+            "full_picture": "https://fbcdn-photos-c-a.akamaihd.net/hphotos-ak-ash3/1175714_410000000000006_1268434293_full_picture.png",
             "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/yz/r/zzzz3.gif",
             "id": "100000000000003_410000000000005",
             "likes": {

--- a/facebook4j-core/src/test/resources/mock_json/post/post.json
+++ b/facebook4j-core/src/test/resources/mock_json/post/post.json
@@ -25,6 +25,7 @@
         "id": "19292868552",
         "name": "Facebook Developers"
     },
+    "full_picture": "https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F&full_picture",
     "icon": "https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-prn1/851582_10151414659411134_455889750_n.gif",
     "id": "19292868552_10150189643478553",
     "likes": {


### PR DESCRIPTION
Hello,

We had need to use a not-so-documented feature for the /post, /feed and /home endpoints to retrieve the original and/or full sized image from the feed. The feature, while not documented on their API pages (for any version), is presented on the Graph API debugger tool. The field "full_picture" is returned by Facebook if it is provided as part of the "fields" parameter. Therefore, with this pull request the new "Post.getFullPicture()" method will return a value if "full_picture" is added as a Reading field.

Cheers.
Martin
