### PR TITLE
Support extending an access token expiration

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
@@ -269,12 +269,12 @@ abstract class FacebookBaseImpl implements Serializable, OAuthSupport {
         getOAuth().setOAuthCallbackURL(callbackURL);
     }
 
-    public AccessToken extendAccessToken(String accessToken) throws FacebookException {
-        return getOAuth().extendAccessToken(accessToken);
+    public AccessToken extendTokenExpiration(String shortLivedToken) throws FacebookException {
+        return getOAuth().extendTokenExpiration(shortLivedToken);
     }
 
-    public AccessToken extendAccessToken() throws FacebookException {
-        return extendAccessToken(getOAuth().getOAuthAccessToken().getToken());
+    public AccessToken extendTokenExpiration() throws FacebookException {
+        return extendTokenExpiration(getOAuth().getOAuthAccessToken().getToken());
     }
 
     private OAuthSupport getOAuth() {

--- a/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
@@ -269,6 +269,14 @@ abstract class FacebookBaseImpl implements Serializable, OAuthSupport {
         getOAuth().setOAuthCallbackURL(callbackURL);
     }
 
+    public AccessToken extendAccessToken(String accessToken) throws FacebookException {
+        return getOAuth().extendAccessToken(accessToken);
+    }
+
+    public AccessToken extendAccessToken() throws FacebookException {
+        return extendAccessToken(getOAuth().getOAuthAccessToken().getToken());
+    }
+
     private OAuthSupport getOAuth() {
         if (!(auth instanceof OAuthSupport)) {
             throw new IllegalStateException("OAuth app id/secret combination not supplied");

--- a/facebook4j-core/src/main/java/facebook4j/auth/OAuthAuthorization.java
+++ b/facebook4j-core/src/main/java/facebook4j/auth/OAuthAuthorization.java
@@ -173,22 +173,22 @@ public class OAuthAuthorization implements Authorization, OAuthSupport, Security
         this.permissions = permissions;
     }
 
-    public AccessToken extendAccessToken(String accessToken) throws FacebookException {
-        String url = getExtendAccessTokenURL(this.appId, this.appSecret, accessToken);
+    public AccessToken extendTokenExpiration(String shortLivedToken) throws FacebookException {
+        String url = getExtendTokenURL(shortLivedToken);
         HttpResponse response = http.get(url);
         if (response.getStatusCode() != 200) {
-            throw new FacebookException("access token extention failed.");
+            throw new FacebookException("token expiration extention failed.");
         }
         this.oauthToken = new AccessToken(response);
         return this.oauthToken;
     }
 
-    protected String getExtendAccessTokenURL(String appId, String appSecret, String accessToken) {
+    protected String getExtendTokenURL(String shortLivedToken) {
         return conf.getOAuthAccessTokenURL() +
                 "?grant_type=fb_exchange_token" +
-                "&client_id=" + appId +
-                "&client_secret=" + appSecret +
-                "&fb_exchange_token=" + accessToken;
+                "&client_id=" + this.appId +
+                "&client_secret=" + this.appSecret +
+                "&fb_exchange_token=" + shortLivedToken;
     }
 
 

--- a/facebook4j-core/src/main/java/facebook4j/auth/OAuthAuthorization.java
+++ b/facebook4j-core/src/main/java/facebook4j/auth/OAuthAuthorization.java
@@ -129,7 +129,7 @@ public class OAuthAuthorization implements Authorization, OAuthSupport, Security
         ensureTokenIsAvailable();
         return this.oauthToken;
     }
-    
+
     public AccessToken getOAuthAppAccessToken() throws FacebookException {
         String url = getAppAccessTokenURL();
         HttpResponse response = http.get(url);
@@ -172,6 +172,25 @@ public class OAuthAuthorization implements Authorization, OAuthSupport, Security
     public void setOAuthPermissions(String permissions) {
         this.permissions = permissions;
     }
+
+    public AccessToken extendAccessToken(String accessToken) throws FacebookException {
+        String url = getExtendAccessTokenURL(this.appId, this.appSecret, accessToken);
+        HttpResponse response = http.get(url);
+        if (response.getStatusCode() != 200) {
+            throw new FacebookException("access token extention failed.");
+        }
+        this.oauthToken = new AccessToken(response);
+        return this.oauthToken;
+    }
+
+    protected String getExtendAccessTokenURL(String appId, String appSecret, String accessToken) {
+        return conf.getOAuthAccessTokenURL() +
+                "?grant_type=fb_exchange_token" +
+                "&client_id=" + appId +
+                "&client_secret=" + appSecret +
+                "&fb_exchange_token=" + accessToken;
+    }
+
 
     public void setAppSecretProofEnabled(boolean enabled) {
         this.appSecretProofEnabled = enabled;

--- a/facebook4j-core/src/main/java/facebook4j/auth/OAuthSupport.java
+++ b/facebook4j-core/src/main/java/facebook4j/auth/OAuthSupport.java
@@ -102,4 +102,13 @@ public interface OAuthSupport {
     void setOAuthCallbackURL(String callbackURL);
 
 
+    /**
+     * Extends long-lived token from the short-lived token of this App.
+     * @param accessToken Short-lived access token
+     * @return Long-lived access token
+     * @throws FacebookException when Facebook service or network is unavailable, or the user has not authorized
+     * @see <a href="https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension">Expiration and Extension of Access Tokens - Facebook Login</a>
+     */
+    AccessToken extendAccessToken(String accessToken) throws FacebookException;
+
 }

--- a/facebook4j-core/src/main/java/facebook4j/auth/OAuthSupport.java
+++ b/facebook4j-core/src/main/java/facebook4j/auth/OAuthSupport.java
@@ -103,12 +103,12 @@ public interface OAuthSupport {
 
 
     /**
-     * Extends long-lived token from the short-lived token of this App.
-     * @param accessToken Short-lived access token
-     * @return Long-lived access token
+     * Extends the short-lived-token expiration.
+     * @param shortLivedToken access token
+     * @return extended access token
      * @throws FacebookException when Facebook service or network is unavailable, or the user has not authorized
      * @see <a href="https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension">Expiration and Extension of Access Tokens - Facebook Login</a>
      */
-    AccessToken extendAccessToken(String accessToken) throws FacebookException;
+    AccessToken extendTokenExpiration(String shortLivedToken) throws FacebookException;
 
 }

--- a/facebook4j-core/src/test/java/facebook4j/auth/OAuthAuthorizationTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/auth/OAuthAuthorizationTest.java
@@ -16,9 +16,14 @@
 
 package facebook4j.auth;
 
+import facebook4j.Facebook;
+import facebook4j.FacebookFactory;
+import facebook4j.FacebookTestBase;
 import facebook4j.conf.Configuration;
 import facebook4j.conf.ConfigurationBuilder;
+import facebook4j.junit.category.RealAPITests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
@@ -27,6 +32,21 @@ import static org.junit.Assert.*;
 
 @RunWith(Enclosed.class)
 public class OAuthAuthorizationTest {
+
+    public static class TokenExpirationExtention extends FacebookTestBase {
+        @Test
+        @Category(RealAPITests.class)
+        public void shortToLong() throws Exception {
+            Facebook facebook = FacebookFactory.getSingleton();
+            String oAuthAppId = p.getProperty("oauth.appId");
+            String oAuthAppSecret = p.getProperty("oauth.appSecret");
+            facebook.setOAuthAppId(oAuthAppId, oAuthAppSecret);
+
+            String shortLivedToken = "your-short-lived-token";
+            AccessToken extendedToken = facebook.extendTokenExpiration(shortLivedToken);
+            assertThat(extendedToken.getToken(), is(not(shortLivedToken)));
+        }
+    }
 
     public static class AppSecretProof {
         @Test


### PR DESCRIPTION
This pull request adds feature of extending an access token expiration.

Facebook's official documentation is:
[Expiration and Extension of Access Tokens - Facebook Login](https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension)