### PR TITLE
Fix infinite recursion at facebook4j.FacebookBaseImpl.extendTokenExpiration(FacebookBaseImpl.java:296) ~[facebook4j-core-2.4.0.jar:2.4.0]

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/FacebookBaseImpl.java
@@ -293,7 +293,7 @@ abstract class FacebookBaseImpl implements Serializable, OAuthSupport {
     }
 
     public AccessToken extendTokenExpiration() throws FacebookException {
-        return extendTokenExpiration();
+        return extendTokenExpiration(getOAuthAccessToken().getToken());
     }
 
     public AccessToken getOAuthAccessTokenInfo(String accessToken) throws FacebookException {


### PR DESCRIPTION
```
Caused by: java.lang.StackOverflowError: null
	at facebook4j.FacebookBaseImpl.extendTokenExpiration(FacebookBaseImpl.java:296) ~[facebook4j-core-2.4.0.jar:2.4.0]
...
```