### PR TITLE
Pull Summary support up from ResponseList to PagableList

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/PagableList.java
+++ b/facebook4j-core/src/main/java/facebook4j/PagableList.java
@@ -24,4 +24,5 @@ import java.util.List;
 public interface PagableList<T> extends List<T> {
     Integer getCount();
     Paging<T> getPaging();
+    Summary getSummary();
 }

--- a/facebook4j-core/src/main/java/facebook4j/ResponseList.java
+++ b/facebook4j-core/src/main/java/facebook4j/ResponseList.java
@@ -21,5 +21,4 @@ package facebook4j;
  * @author Ryuji Yamashita - roundrop at gmail.com
  */
 public interface ResponseList<T> extends PagableList<T> {
-    Summary getSummary();
 }

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/PagableListImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/PagableListImpl.java
@@ -16,15 +16,16 @@
 
 package facebook4j.internal.json;
 
-import facebook4j.FacebookException;
-import facebook4j.PagableList;
-import facebook4j.Paging;
-import facebook4j.internal.org.json.JSONException;
-import facebook4j.internal.org.json.JSONObject;
+import static facebook4j.internal.util.z_F4JInternalParseUtil.getInt;
 
 import java.util.ArrayList;
 
-import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
+import facebook4j.FacebookException;
+import facebook4j.PagableList;
+import facebook4j.Paging;
+import facebook4j.Summary;
+import facebook4j.internal.org.json.JSONException;
+import facebook4j.internal.org.json.JSONObject;
 
 /**
  * @author Ryuji Yamashita - roundrop at gmail.com
@@ -34,6 +35,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
 
     private Integer count;
     private Paging<T> paging;
+    private Summary summary;
 
     /*package*/PagableListImpl() {
         super();
@@ -60,10 +62,19 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
         if (!json.isNull("count")) {
             count = getInt("count", json);
         }
+        
         try {
             if (!json.isNull("paging")) {
                 JSONObject pagingJSONObject = json.getJSONObject("paging");
                 paging = new PagingJSONImpl<T>(pagingJSONObject, jsonObjectType);
+            }
+        } catch (JSONException jsone) {
+            throw new FacebookException(jsone.getMessage(), jsone);
+        }
+        
+        try {
+            if (!json.isNull("summary")) {
+                summary = new SummaryJSONImpl(json.getJSONObject("summary"));
             }
         } catch (JSONException jsone) {
             throw new FacebookException(jsone.getMessage(), jsone);
@@ -77,12 +88,17 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     public Paging<T> getPaging() {
         return paging;
     }
+    
+    public Summary getSummary() {
+        return summary;
+    }
 
     @Override
     public String toString() {
         return "PagableListImpl{" +
                 "count=" + count +
                 ", paging=" + paging +
+                ", summary=" + summary +
                 ", " + super.toString() +
                 '}';
     }

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/ResponseListImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/ResponseListImpl.java
@@ -30,8 +30,6 @@ import facebook4j.internal.org.json.JSONObject;
  */
 /*package*/ class ResponseListImpl<T> extends PagableListImpl<T> implements ResponseList<T> {
 
-    private Summary summary;
-
     /*package*/ResponseListImpl(JSONObject json, T... t) throws FacebookException {
         super(json, t);
         init(json);
@@ -43,13 +41,6 @@ import facebook4j.internal.org.json.JSONObject;
     }
 
     private void init(JSONObject json) throws FacebookException {
-        if (!json.isNull("summary")) {
-            try {
-                summary = new SummaryJSONImpl(json.getJSONObject("summary"));
-            } catch (JSONException jsone) {
-                throw new FacebookException(jsone.getMessage(), jsone);
-            }
-        }
     }
 
     /*package*/
@@ -84,9 +75,5 @@ import facebook4j.internal.org.json.JSONObject;
         } catch (JSONException jsone) {
             throw new FacebookException(jsone);
         }
-    }
-
-    public Summary getSummary() {
-        return summary;
     }
 }

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/VideoJSONImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/VideoJSONImpl.java
@@ -114,7 +114,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
                 if (!commentsJSONObject.isNull("data")) {
                     JSONArray list = commentsJSONObject.getJSONArray("data");
                     final int size = list.length();
-                    comments = new PagableListImpl<Comment>(size, json.getJSONObject("comments"));
+                    comments = new PagableListImpl<Comment>(size, commentsJSONObject);
                     for (int i = 0; i < size; i++) {
                         CommentJSONImpl comment = new CommentJSONImpl(list.getJSONObject(i));
                         comments.add(comment);

--- a/facebook4j-core/src/test/java/facebook4j/PostMethodsTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/PostMethodsTest.java
@@ -585,6 +585,59 @@ public class PostMethodsTest extends MockFacebookTestBase {
         }
 
         @Test
+        public void idWithSummaries() throws Exception {
+            facebook.setMockJSON("mock_json/post/post_with_summaries.json");
+            Post actual = facebook.getPost("19292868552_10150189643478553");
+            assertThat(facebook.getHttpMethod(), is(RequestMethod.GET));
+            assertThat(facebook.getEndpointURL(), is(pathOf("/19292868552_10150189643478553")));
+
+            assertThat(actual.getIcon().toString(), is("https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-prn1/851582_10151414659411134_455889750_n.gif"));
+            assertThat(actual.getApplication().getId(), is("9953271133"));
+            assertThat(actual.getApplication().getName(), is("NetworkedBlogs"));
+            assertThat(actual.getApplication().getNamespace(), is("blognetworks"));
+            assertThat(actual.getLink().toString(), is("http://developers.facebook.com/blog/post/497"));
+            assertThat(actual.getPrivacy().getValue(), is(PrivacyType.EMPTY));
+            assertThat(actual.getFrom().getId(), is("19292868552"));
+            assertThat(actual.getFrom().getCategory(), is("Product/service"));
+            assertThat(actual.getFrom().getName(), is("Facebook Developers"));
+            assertThat(actual.getProperties().size(), is(2));
+            assertThat(actual.getProperties().get(0).getText(), is("Official Facebook Developer Blog"));
+            assertThat(actual.getProperties().get(0).getName(), is("source"));
+            assertThat(actual.getProperties().get(0).getHref(), is("http://apps.facebook.com/blognetworks/blog/official_facebook_developer_blog"));
+            assertThat(actual.getProperties().get(1).getText(), is("Full Article..."));
+            assertThat(actual.getProperties().get(1).getName(), is("link"));
+            assertThat(actual.getProperties().get(1).getHref(), is("http://developers.facebook.com/blog/post/497"));
+            assertThat(actual.getType(), is("link"));
+            assertThat(actual.getUpdatedTime(), is(iso8601DateOf("2013-08-18T12:03:22+0000")));
+            assertThat(actual.getId(), is("19292868552_10150189643478553"));
+            assertThat(actual.getPicture().toString(), is("https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F"));
+            assertThat(actual.getFullPicture().toString(), is("https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F&full_picture"));
+            assertThat(actual.getStatusType(), is("app_created_story"));
+            assertThat(actual.getDescription(), is("\nWe continue to make Platform more secure for users. Earlier this year, we introduced the ability for users to browse Facebook over HTTPS. As a result, we provided \u201cSecure Canvas URL\u201d and \u201cSecure Tab URL\u201d fields in the Developer App for developers to serve their apps through an H"));
+            assertThat(actual.getLikes().getCount(), is(8064));
+            assertThat(actual.getLikes().get(0).getId(), is("100000670927963"));
+            assertThat(actual.getLikes().get(0).getName(), is("Xiaoguang Wang"));
+            assertThat(actual.getLikes().get(1).getId(), is("1011399360"));
+            assertThat(actual.getLikes().get(1).getName(), is("Samuel Silva"));
+            assertThat(actual.getLikes().get(2).getId(), is("100002285148138"));
+            assertThat(actual.getLikes().get(2).getName(), is("Yo Yo Chen"));
+            assertThat(actual.getLikes().get(3).getId(), is("100002741111992"));
+            assertThat(actual.getLikes().get(3).getName(), is("Tony Tang"));
+            assertThat(actual.getLikes().getSummary(), is(notNullValue()));
+            assertThat(actual.getLikes().getSummary().getTotalCount(), is(7882));
+            assertThat(actual.getName(), is("Developer Roadmap Update: Moving to OAuth 2.0 + HTTPS"));
+            assertThat(actual.getCreatedTime(), is(iso8601DateOf("2011-05-10T18:35:38+0000")));
+            assertThat(actual.getActions().size(), is(3));
+            assertThat(actual.getActions().get(0).getName(), is("Comment"));
+            assertThat(actual.getActions().get(0).getLink().toString(), is("https://www.facebook.com/19292868552/posts/10150189643478553"));
+            assertThat(actual.getActions().get(1).getName(), is("Like"));
+            assertThat(actual.getActions().get(1).getLink().toString(), is("https://www.facebook.com/19292868552/posts/10150189643478553"));
+            assertThat(actual.getActions().get(2).getName(), is("Share"));
+            assertThat(actual.getActions().get(2).getLink().toString(), is("http://networkedblogs.com/hGWk3?a=share"));
+            assertThat(actual.getScheduledPublishTime(), is(nullValue()));
+        }
+
+        @Test
         public void reading() throws Exception {
             facebook.setMockJSON("mock_json/post/post_picture.json");
             Post actual = facebook.getPost("19292868552_10150189643478553", new Reading().fields("picture"));

--- a/facebook4j-core/src/test/resources/mock_json/post/post_with_summaries.json
+++ b/facebook4j-core/src/test/resources/mock_json/post/post_with_summaries.json
@@ -1,0 +1,76 @@
+{
+    "actions": [
+        {
+            "link": "https://www.facebook.com/19292868552/posts/10150189643478553",
+            "name": "Comment"
+        },
+        {
+            "link": "https://www.facebook.com/19292868552/posts/10150189643478553",
+            "name": "Like"
+        },
+        {
+            "link": "http://networkedblogs.com/hGWk3?a=share",
+            "name": "Share"
+        }
+    ],
+    "application": {
+        "id": "9953271133",
+        "name": "NetworkedBlogs",
+        "namespace": "blognetworks"
+    },
+    "created_time": "2011-05-10T18:35:38+0000",
+    "description": "\nWe continue to make Platform more secure for users. Earlier this year, we introduced the ability for users to browse Facebook over HTTPS. As a result, we provided \u201cSecure Canvas URL\u201d and \u201cSecure Tab URL\u201d fields in the Developer App for developers to serve their apps through an H",
+    "from": {
+        "category": "Product/service",
+        "id": "19292868552",
+        "name": "Facebook Developers"
+    },
+    "full_picture": "https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F&full_picture",
+    "icon": "https://fbcdn-photos-g-a.akamaihd.net/hphotos-ak-prn1/851582_10151414659411134_455889750_n.gif",
+    "id": "19292868552_10150189643478553",
+    "likes": {
+        "count": 8064,
+        "data": [
+            {
+                "id": "100000670927963",
+                "name": "Xiaoguang Wang"
+            },
+            {
+                "id": "1011399360",
+                "name": "Samuel Silva"
+            },
+            {
+                "id": "100002285148138",
+                "name": "Yo Yo Chen"
+            },
+            {
+                "id": "100002741111992",
+                "name": "Tony Tang"
+            }
+        ],
+        "summary": {
+            "total_count": 7882,
+            "can_like": true,
+            "has_liked": false
+        }
+    },
+    "link": "http://developers.facebook.com/blog/post/497",
+    "name": "Developer Roadmap Update: Moving to OAuth 2.0 + HTTPS",
+    "picture": "https://fbexternal-a.akamaihd.net/app_full_proxy.php?app=9953271133&v=3&size=z&cksum=e15ac22d55f6a9501d3b3ac64c5fb763&src=http%3A%2F%2Fimg.bitpixels.com%2Fgetthumbnail%3Fcode%3D78793%26size%3D120%26url%3Dhttp%3A%2F%2Fdevelopers.facebook.com%2Fblog%2F",
+    "privacy": {"value": ""},
+    "properties": [
+        {
+            "href": "http://apps.facebook.com/blognetworks/blog/official_facebook_developer_blog",
+            "name": "source",
+            "text": "Official Facebook Developer Blog"
+        },
+        {
+            "href": "http://developers.facebook.com/blog/post/497",
+            "name": "link",
+            "text": "Full Article..."
+        }
+    ],
+    "status_type": "app_created_story",
+    "type": "link",
+    "updated_time": "2013-08-18T12:03:22+0000"
+}


### PR DESCRIPTION
First, let me say "thank you" for building facebook4j. It makes a complex API easy to use in Java, and that's no small task. It's awesome!

I did have a small problem when I was trying to pull a Post feed, though. I wanted to include total likes in my data, so I was making the following request in facebook4j (with many fields removed here for clarity):

    ResponseList<facebook4j.Post> feed=facebook.getPosts(id, new Reading()
        .fields("id", "likes.limit(0).summary(true)")
        .limit(100));

I found that no matter how many likes a post had, a Post's like count always came back as at most the likes limit in the clause above:

    post.getLikes().getCount(); // <-- never more than limit, even if total likes is higher

I checked the code and saw that this was because the code wasn't attempting to pull the total count out from the likes summary and instead just treated the contents of the data array as an exhaustive list. I've made some small edits to the code that will cause the library to incorporate data from the summary when it's available, allowing users to access the total counts.

In short, here are the changes I made:

* Pull summary attribute up from ResponseList to its superclass PagableList
* PagableList#init() now reads the Summary object
* Added test and corresponding resource to confirm implementation works

These changes should be safe to integrate because I only pulled one method up to its superclass, which shouldn't break anyone's code. (The method still exists in the child class; it's simply defined in the parent now.)

Hopefully the changes I've made are clear and you find the code to be of high enough quality to integrate into the library. If you have any questions or concerns, please let me know and I'll update my pull request!