### PR TITLE
Add method for searching public objects of given type

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/FacebookImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/FacebookImpl.java
@@ -2333,7 +2333,11 @@ class FacebookImpl extends FacebookBaseImpl implements Facebook {
     }
 
     public ResponseList<JSONObject> search(String query, Reading reading) throws FacebookException {
-        String url = buildSearchEndpoint(query, null, reading);
+        return search(query, null, null);
+    }
+    
+    public ResponseList<JSONObject> search(String query,String type, Reading reading) throws FacebookException {
+        String url = buildSearchEndpoint(query, type, reading);
         return factory.createJSONObjectList(get(url));
     }
 

--- a/facebook4j-core/src/main/java/facebook4j/api/SearchMethods.java
+++ b/facebook4j-core/src/main/java/facebook4j/api/SearchMethods.java
@@ -240,5 +240,16 @@ public interface SearchMethods {
      * @throws FacebookException when Facebook service or network is unavailable
      */
     ResponseList<JSONObject> search(String query, Reading reading) throws FacebookException;
+    
+    /**
+     * Searches all public objects of given type.
+     * @param query the search condition
+     * @param object type
+     * @param reading optional reading parameters. see <a href="https://developers.facebook.com/docs/reference/api/#reading">Graph API#reading - Facebook Developers</a>
+     * @return objects
+     * @throws FacebookException when Facebook service or network is unavailable
+     */
+    ResponseList<JSONObject> search(String query, String type, Reading reading) throws FacebookException;
+
 
 }


### PR DESCRIPTION
I've overloaded search method from SearchMethods interface to add possibility of declaring type of searched object.

One simple case where this is needed is query for pages category list: "search?type=placetopic&topic_filter=all".