### PR TITLE
add token_for_business field to user entity

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/User.java
+++ b/facebook4j-core/src/main/java/facebook4j/User.java
@@ -43,6 +43,7 @@ public interface User extends FacebookResponse {
     Boolean isVerified();
     String getBio();
     String getBirthday();
+    String getTokenForBusiness();
     Cover getCover();
     List<User.Education> getEducation();
     String getEmail();

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/UserJSONImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/UserJSONImpl.java
@@ -76,6 +76,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     private String quotes;
     private String relationshipStatus;
     private String religion;
+    private String tokenForBusiness;
     private IdNameEntity significantOther;
     private User.VideoUploadLimits videoUploadLimits;
     private URL website;
@@ -103,6 +104,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
         try {
             id = getRawString("id", json);
             name = getRawString("name", json);
+            tokenForBusiness = getRawString("token_for_business", json);
             firstName = getRawString("first_name", json);
             middleName = getRawString("middle_name", json);
             lastName = getRawString("last_name", json);
@@ -354,6 +356,10 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
         return religion;
     }
 
+    public String getTokenForBusiness() {
+        return tokenForBusiness;
+    }
+
     public IdNameEntity getSignificantOther() {
         return significantOther;
     }
@@ -463,11 +469,11 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
                 + ", favoriteTeams=" + favoriteTeams + ", picture=" + picture
                 + ", quotes=" + quotes + ", relationshipStatus="
                 + relationshipStatus + ", religion=" + religion
+                + ", tokenForBusiness=" + tokenForBusiness
                 + ", significantOther=" + significantOther
                 + ", videoUploadLimits=" + videoUploadLimits + ", website="
                 + website + ", work=" + work + ", ageRange=" + ageRange + "]";
     }
-
 
 
     private final class EducationJSONImpl implements User.Education, java.io.Serializable {

--- a/facebook4j-core/src/test/java/facebook4j/UserMethodsTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/UserMethodsTest.java
@@ -53,6 +53,7 @@ public class UserMethodsTest extends MockFacebookTestBase {
             assertThat(me.getEducation().get(1).getYear().getId(), is("4444"));
             assertThat(me.getEducation().get(1).getYear().getName(), is("1998"));
             assertThat(me.getEmail(), is("roundrop@gmail.com"));
+            assertThat(me.getTokenForBusiness(), is("Abb5ew2lsjN9FA70"));
             assertThat(me.getFirstName(), is("Firstname"));
             assertThat(me.getGender(), is("male"));
             assertThat(me.getHometown().getId(), is("5555"));

--- a/facebook4j-core/src/test/resources/mock_json/user/me.json
+++ b/facebook4j-core/src/test/resources/mock_json/user/me.json
@@ -28,6 +28,7 @@
     "email": "roundrop@gmail.com",
     "first_name": "Firstname",
     "gender": "male",
+    "token_for_business": "Abb5ew2lsjN9FA70",
     "hometown": {
         "id": "5555",
         "name": "Hometown Name"


### PR DESCRIPTION
I added a new field which is 'token_for_business' to the user entity.
The reason I do this is because we have multiple apps for one Facebook account, but our user's ID  is different between apps, which make me unable to mark users by one and only ID. So I need to add a 'token_for_business' to map the same person's ID. 
Here listed below is the document for that 'token_for_business'. If you can approve my request in a very short time, then I can continue my development ASAP, which make your help means a lot to me! Thanks very much!
[https://developers.facebook.com/docs/apps/for-business](https://developers.facebook.com/docs/apps/for-business)