### PR TITLE
Added Album.getPicture() method

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/Album.java
+++ b/facebook4j-core/src/main/java/facebook4j/Album.java
@@ -37,7 +37,8 @@ public interface Album extends FacebookResponse {
     Date getUpdatedTime();
     Boolean canUpload();
     Place getPlace();
-    
+    Picture getPicture();
+
     PagableList<Like> getLikes();
     PagableList<Comment> getComments();
     PagableList<Reaction> getReactions();

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/AlbumJSONImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/AlbumJSONImpl.java
@@ -48,7 +48,8 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     private Date updatedTime;
     private Boolean canUpload;
     private Place place;
-    
+    private Picture picture;
+
     private PagableList<Like> likes;
     private PagableList<Comment> comments;
     private PagableList<Reaction> reactions;
@@ -90,7 +91,14 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
                 JSONObject placeJSONObject = json.getJSONObject("place");
                 place = new PlaceJSONImpl(placeJSONObject);
             }
-            
+
+            if (!json.isNull("picture")) {
+                JSONObject pictureJSONObject = json.getJSONObject("picture");
+                if (!pictureJSONObject.isNull("data")) {
+                    picture = new PictureJSONImpl(pictureJSONObject);
+                }
+            }
+
             if (!json.isNull("likes")) {
                 JSONObject likesJSONObject = json.getJSONObject("likes");
                 if (!likesJSONObject.isNull("data")) {
@@ -124,7 +132,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
             } else {
                 comments = new PagableListImpl<Comment>(0);
             }
-            
+
             if (!json.isNull("reactions")) {
                 JSONObject reactionsJSONObject = json.getJSONObject("reactions");
                 if (!reactionsJSONObject.isNull("data")) {
@@ -203,6 +211,10 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
         return place;
     }
 
+    public Picture getPicture() {
+        return picture;
+    }
+
     public PagableList<Like> getLikes() {
         return likes;
     }
@@ -214,7 +226,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     public PagableList<Reaction> getReactions() {
         return reactions;
     }
-    
+
     /*package*/
     static ResponseList<Album> createAlbumList(HttpResponse res, Configuration conf) throws FacebookException {
         try {
@@ -284,6 +296,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
                  ", updatedTime=" + updatedTime +
                  ", canUpload=" + canUpload +
                  ", place=" + place +
+                 ", picture=" + picture +
                  ", likes=" + likes +
                  ", comments=" + comments +
                  '}';


### PR DESCRIPTION
Added method to get an albums picture. This should be the cover photo, but seems you cannot get a URL for the image that way. This seems like the only way to get a link/url to the actual image for a given album. This is the album cover photo, or primary photo. Other methods did not seem to make this available.

Requires Reading fields ```"picture{url}"```
```java
ResponseList<Album> feed = facebook.getAlbums("Page", new Reading().fields(picture{url}));
feed.stream().foreach(album -> {
    URL picture = album.getPicture().getURL();
});
```
Sample Album JSON ```fields=id,name,picture{url}```
```json
{
  "data": [
  {
      "id": "11111111111111111",
      "name": "Album name",
      "picture": {
        "data": {
          "url": "https://scontent.xx.fbcdn.net/v/.....jpg"
        }
      }
    }
  ]
```
