### PR TITLE
Page likes work incorrectly

### DIFF
--- a/facebook4j-core/src/main/java/facebook4j/FacebookImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/FacebookImpl.java
@@ -1535,6 +1535,15 @@ class FacebookImpl extends FacebookBaseImpl implements Facebook {
         return factory.createPage(res);
     }
 
+    public ResponseList<Like> getPageLikes(String pageId) throws FacebookException {
+        return getPageLikes(pageId, null);
+    }
+
+    public ResponseList<Like> getPageLikes(String pageId, Reading reading) throws FacebookException {
+        ensureAuthorizationEnabled();
+        return factory.createLikeList(get(buildEndpoint(pageId, "likes", reading)));
+    }
+
     public URL getPagePictureURL() throws FacebookException {
         return getPagePictureURL("me", null);
     }

--- a/facebook4j-core/src/main/java/facebook4j/Page.java
+++ b/facebook4j-core/src/main/java/facebook4j/Page.java
@@ -31,12 +31,6 @@ public interface Page {
     String getCategory();
     Boolean isPublished();
     Boolean canPost();
-
-    /**
-     * Number of pages this page likes.
-     * @return
-     */
-    Integer getLikes();
     Place.Location getLocation();
     String getPhone();
     Integer getCheckins();
@@ -64,5 +58,7 @@ public interface Page {
     String getUsername();
     String getMission();
     Map<String,String> getHours();
+
+    PagableList<Like> getLikes();
 
 }

--- a/facebook4j-core/src/main/java/facebook4j/api/PageMethods.java
+++ b/facebook4j-core/src/main/java/facebook4j/api/PageMethods.java
@@ -20,6 +20,7 @@ import facebook4j.Admin;
 import facebook4j.BackdatingPostUpdate;
 import facebook4j.FacebookException;
 import facebook4j.Insight;
+import facebook4j.Like;
 import facebook4j.Media;
 import facebook4j.Milestone;
 import facebook4j.MilestoneUpdate;
@@ -794,5 +795,23 @@ public interface PageMethods {
      * @see <a href="https://developers.facebook.com/docs/reference/api/user/#likes">User#likes - Facebook Developers</a>
      */
     Page getLikedPage(String userId, String pageId, Reading reading) throws FacebookException;
-    
+
+    /**
+     * Returns likes made by the page.
+     * @param pageId the ID of a page
+     * @return likes
+     * @throws FacebookException when Facebook service or network is unavailable
+     * @see <a href="https://developers.facebook.com/docs/graph-api/reference/page/likes">Page Likes - Facebook Developers</a>
+     */
+    ResponseList<Like> getPageLikes(String pageId) throws FacebookException;
+
+    /**
+     * Returns likes made by the page.
+     * @param pageId the ID of a page
+     * @param reading optional reading parameters. see <a href="https://developers.facebook.com/docs/reference/api/#reading">Graph API#reading - Facebook Developers</a> see <a href="https://developers.facebook.com/docs/reference/api/#reading">Graph API#reading - Facebook Developers</a>
+     * @return likes
+     * @throws FacebookException when Facebook service or network is unavailable
+     * @see <a href="https://developers.facebook.com/docs/graph-api/reference/page/likes">Page Likes - Facebook Developers</a>
+     */
+    ResponseList<Like> getPageLikes(String pageId, Reading reading) throws FacebookException;
 }

--- a/facebook4j-core/src/main/java/facebook4j/internal/json/PageJSONImpl.java
+++ b/facebook4j-core/src/main/java/facebook4j/internal/json/PageJSONImpl.java
@@ -44,7 +44,6 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     private URL link;
     private Boolean isPublished;
     private Boolean canPost;
-    private Integer likes;
     private Place.Location location;
     private String phone;
     private Integer checkins;
@@ -62,6 +61,8 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
     private String mission;
     private Map<String,String> hours;
 
+    private PagableList<Like> likes;
+    
     /*package*/PageJSONImpl(HttpResponse res, Configuration conf) throws FacebookException {
         super(res);
         JSONObject json = res.asJSONObject();
@@ -86,7 +87,24 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
             link = getURL("link", json);
             isPublished = getBoolean("is_published", json);
             canPost = getBoolean("can_post", json);
-            likes = getInt("likes", json);
+
+            if (!json.isNull("likes")) {
+                JSONObject likesJSONObject = json.getJSONObject("likes");
+                if (!likesJSONObject.isNull("data")) {
+                    JSONArray list = likesJSONObject.getJSONArray("data");
+                    final int size = list.length();
+                    likes = new PagableListImpl<Like>(size, likesJSONObject);
+                    for (int i = 0; i < size; i++) {
+                        LikeJSONImpl like = new LikeJSONImpl(list.getJSONObject(i));
+                        likes.add(like);
+                    }
+                } else {
+                    likes = new PagableListImpl<Like>(1, likesJSONObject);
+                }
+            } else {
+                likes = new PagableListImpl<Like>(0);
+            }
+            
             if (!json.isNull("location")) {
                 JSONObject locationJSONObject = json.getJSONObject("location");
                 location = new PlaceJSONImpl.LocationJSONImpl(locationJSONObject);
@@ -146,7 +164,7 @@ import static facebook4j.internal.util.z_F4JInternalParseUtil.*;
         return canPost;
     }
 
-    public Integer getLikes() {
+    public PagableList<Like> getLikes() {
         return likes;
     }
 

--- a/facebook4j-core/src/test/java/facebook4j/PageMethodsTest.java
+++ b/facebook4j-core/src/test/java/facebook4j/PageMethodsTest.java
@@ -16,17 +16,10 @@
 
 package facebook4j;
 
-import facebook4j.internal.http.HttpParameter;
 import facebook4j.internal.http.RequestMethod;
-import facebook4j.internal.org.json.JSONArray;
-import facebook4j.internal.org.json.JSONException;
-import facebook4j.internal.org.json.JSONObject;
 import facebook4j.junit.FacebookAPIVersion;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.internal.matchers.TypeSafeMatcher;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -90,6 +83,16 @@ public class PageMethodsTest {
         }
 
         @Test
+        public void likes() throws Exception {
+            facebook.setMockJSON("mock_json/page/likes.json");
+            ResponseList<Like> likes = facebook.getPageLikes("10150146071791729");
+
+            assertThat(likes.size(), is(2));
+            assertThat(likes.get(0).getName(), is("Iveta Frybertova"));
+            assertThat(likes.get(1).getName(), is("Adel Youssef Youssef"));
+        }
+
+        @Test
         public void about_and_username() throws Exception {
             facebook.setMockJSON("mock_json/page/platform.json");
             Page actual = facebook.getPage("platform");
@@ -136,6 +139,7 @@ public class PageMethodsTest {
             assertThat(actual.getHours().size(), is(28));
             assertThat(actual.getHours().get("sat_2_close"), is("22:00"));
         }
+        
     }
 
     public static class getPagePictureURL extends MockFacebookTestBase {

--- a/facebook4j-core/src/test/resources/mock_json/page/f4j.json
+++ b/facebook4j-core/src/test/resources/mock_json/page/f4j.json
@@ -10,7 +10,9 @@
     "id": "137246726435626",
     "is_community_page": false,
     "is_published": false,
-    "likes": 0,
+    "likes": {
+        "data": []
+    },
     "link": "http://www.facebook.com/pages/F4J/137246726435626",
     "name": "F4J",
     "new_like_count": 0,

--- a/facebook4j-core/src/test/resources/mock_json/page/likes.json
+++ b/facebook4j-core/src/test/resources/mock_json/page/likes.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "id": "100002157503112",
+      "name": "Iveta Frybertova"
+    },
+    {
+      "id": "100003337717356",
+      "name": "Adel Youssef Youssef"
+    }
+  ],
+  "paging": {
+    "cursors": {
+      "after": "MTAwMDAwNjM2MjQzMTQx",
+      "before": "MTAwMDAyMTU3NTAzMTEy"
+    },
+    "next": "https://graph.facebook.com/10150146071791729/likes?access_token=access_token&limit=25&after=MTAwMDAwNjM2MjQzMTQx"
+  }
+}

--- a/facebook4j-core/src/test/resources/mock_json/page/platform.json
+++ b/facebook4j-core/src/test/resources/mock_json/page/platform.json
@@ -14,7 +14,9 @@
     "id": "19292868552",
     "is_community_page": false,
     "is_published": true,
-    "likes": 3270042,
+    "likes": {
+        "data": []
+    },
     "link": "https://www.facebook.com/FacebookDevelopers",
     "name": "Facebook Developers",
     "parking": {


### PR DESCRIPTION
According to official [docs](https://developers.facebook.com/docs/graph-api/reference/page/likes):

> Reading from this edge will return a JSON formatted result:
> 
> {
>     "data": [],
>     "paging": {},
>     "summary": {}
> }

not a `Integer` count as it is now.