### PR TITLE
Fix Travis-CI to use openjdk6

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip
+distributionUrl=http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: java
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-jdk:
-  - openjdk6
-cache:
-  directories:
-  - $HOME/.m2
+env:
+  global:
+    - TRAVIS_JDK=zulu@1.6.103
+    - JABBA_HOME=/home/travis/.jabba
+before_install:
+  - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+install:
+  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK && export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
 before_script:
+  - unset _JAVA_OPTIONS
   - echo "debug=false" >> facebook4j-core/src/test/resources/test.properties &&  echo "oauth.appId=1" >> facebook4j-core/src/test/resources/test.properties && echo "oauth.appSecret=1" >> facebook4j-core/src/test/resources/test.properties && echo "oauth.accessToken=access_token" >> facebook4j-core/src/test/resources/test.properties
 after_success:
   - ./mvnw -pl facebook4j-core clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:cobertura
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.jabba/jdk


### PR DESCRIPTION
From Travis-CI: https://travis-ci.org/roundrop/facebook4j/builds/415751819

## Problem

### cannot use openjdb6

```
$ jdk_switcher use openjdk6
Switching to OpenJDK6 (java-1.6.0-openjdk-amd64), JAVA_HOME will be set to /usr/lib/jvm/java-6-openjdk-amd64
update-java-alternatives: directory does not exist: /usr/lib/jvm/java-1.6.0-openjdk-amd64
apt
:
$ java -Xmx32m -version
java version "1.8.0_151"
Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)
$ javac -J-Xmx32m -version
javac 1.8.0_151
:
```

### Failed to download Maven via mvnw

```
4.62s$ ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
Downloading https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip
Exception in thread "main" javax.net.ssl.SSLException: Received fatal alert: protocol_version
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:208)
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:154)
	at sun.security.ssl.SSLSocketImpl.recvAlert(SSLSocketImpl.java:1902)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1074)
	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1320)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1347)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1331)
	at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:432)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1278)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
	at org.apache.maven.wrapper.DefaultDownloader.downloadInternal(DefaultDownloader.java:73)
	at org.apache.maven.wrapper.DefaultDownloader.download(DefaultDownloader.java:60)
	at org.apache.maven.wrapper.Installer.createDist(Installer.java:64)
	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:121)
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:60)
        :
```

## Solution

1. make download Maven (via mvnw) using http instead of https
2. apply Azul Zulu OpenJDK 6 using Jabba
    - working around: https://github.com/travis-ci/travis-ci/issues/9713
    - solution blog post: http://eed3si9n.com/ja/all-your-jdks-on-travis-ci-using-jabba